### PR TITLE
feat(pwa): Sprint 5 — Offline BL consultation

### DIFF
--- a/assets/controllers/bl_detail_controller.js
+++ b/assets/controllers/bl_detail_controller.js
@@ -1,0 +1,225 @@
+import { Controller } from '@hotwired/stimulus';
+import { getBLDetail, getBLImage } from '../js/blCacheManager.js';
+import { getLastBLSyncTime } from '../js/db.js';
+
+export default class extends Controller {
+    static values = { blId: Number };
+    static targets = ['header', 'image', 'data', 'loading', 'cacheStatus', 'info', 'lines'];
+
+    async connect() {
+        await this.loadBL();
+    }
+
+    async loadBL() {
+        this.loadingTarget.classList.remove('hidden');
+        this.dataTarget.classList.add('hidden');
+
+        try {
+            const bl = await getBLDetail(this.blIdValue);
+
+            if (!bl) {
+                this.loadingTarget.innerHTML = `
+                    <div class="bl-empty-state">
+                        <div class="bl-empty-state__icon"><i class="fas fa-exclamation-circle"></i></div>
+                        <h3 class="bl-empty-state__title">BL non trouvé</h3>
+                        <p class="bl-empty-state__text">Ce bon de livraison n'est pas dans le cache. Vérifiez votre connexion.</p>
+                    </div>
+                `;
+                return;
+            }
+
+            this.renderBL(bl);
+            this.loadImage(bl);
+            this.updateCacheStatus();
+        } catch (error) {
+            console.error('[BLDetail] Erreur:', error);
+            this.loadingTarget.innerHTML = '<p class="text-red-600 text-center">Erreur lors du chargement.</p>';
+        }
+    }
+
+    renderBL(bl) {
+        this.loadingTarget.classList.add('hidden');
+        this.dataTarget.classList.remove('hidden');
+
+        // Update page header
+        const numeroBl = bl.numeroBl ? `N° ${this.escapeHtml(bl.numeroBl)}` : `#${bl.id}`;
+        this.headerTarget.innerHTML = `
+            <i class="fas fa-file-invoice mr-2"></i>
+            BL ${numeroBl}
+        `;
+
+        // Render info section
+        this.renderInfo(bl);
+
+        // Render lines table
+        this.renderLines(bl);
+    }
+
+    renderInfo(bl) {
+        const isAnomalie = bl.statut === 'ANOMALIE';
+        const badgeClass = isAnomalie ? 'bl-status-badge--anomalie' : 'bl-status-badge--valide';
+        const badgeIcon = isAnomalie ? 'exclamation-triangle' : 'check-circle';
+        const badgeLabel = isAnomalie ? 'Anomalie' : 'Validé';
+
+        const dateLivraison = bl.dateLivraison
+            ? new Date(bl.dateLivraison).toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' })
+            : '—';
+
+        const validatedAt = bl.validatedAt
+            ? new Date(bl.validatedAt).toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+            : '—';
+
+        const totalHt = bl.totalHt
+            ? parseFloat(bl.totalHt).toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })
+            : '—';
+
+        const fournisseur = bl.fournisseur?.nom || '—';
+        const etablissement = bl.etablissement?.nom || '—';
+        const numeroBl = bl.numeroBl || '—';
+        const nbLignes = bl.lignes?.length || 0;
+        const nbAlertes = bl.lignes?.reduce((sum, l) => sum + (l.alertes?.length || 0), 0) || 0;
+
+        this.infoTarget.innerHTML = `
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="bl-detail-header__title">Informations</h2>
+                <span class="bl-status-badge ${badgeClass}">
+                    <i class="fas fa-${badgeIcon}"></i>
+                    ${badgeLabel}
+                </span>
+            </div>
+            <div class="bl-detail-header__grid">
+                <div>
+                    <div class="bl-detail-header__label">N° BL</div>
+                    <div class="bl-detail-header__value">${this.escapeHtml(numeroBl)}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Date livraison</div>
+                    <div class="bl-detail-header__value">${dateLivraison}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Fournisseur</div>
+                    <div class="bl-detail-header__value">${this.escapeHtml(fournisseur)}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Établissement</div>
+                    <div class="bl-detail-header__value">${this.escapeHtml(etablissement)}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Total HT</div>
+                    <div class="bl-detail-header__value">${totalHt}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Validé le</div>
+                    <div class="bl-detail-header__value">${validatedAt}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Lignes</div>
+                    <div class="bl-detail-header__value">${nbLignes}</div>
+                </div>
+                <div>
+                    <div class="bl-detail-header__label">Alertes</div>
+                    <div class="bl-detail-header__value">${nbAlertes > 0 ? '<span class="text-red-600">' + nbAlertes + ' alerte(s)</span>' : '0'}</div>
+                </div>
+            </div>
+        `;
+    }
+
+    renderLines(bl) {
+        const lignes = bl.lignes || [];
+
+        if (lignes.length === 0) {
+            this.linesTarget.innerHTML = `
+                <div class="bl-detail-table-header">Lignes</div>
+                <div class="p-6 text-center text-gray-500">Aucune ligne</div>
+            `;
+            return;
+        }
+
+        const rows = lignes.map(ligne => {
+            const hasAlertes = ligne.alertes && ligne.alertes.length > 0;
+            const rowClass = hasAlertes ? 'bl-alert-row' : '';
+
+            const alerteHtml = hasAlertes
+                ? ligne.alertes.map(a => `
+                    <div class="bl-alert-indicator">
+                        <i class="fas fa-exclamation-circle"></i>
+                        ${this.escapeHtml(a.message)}
+                    </div>
+                `).join('')
+                : '';
+
+            const qty = ligne.quantiteLivree ? parseFloat(ligne.quantiteLivree).toLocaleString('fr-FR') : '—';
+            const prix = ligne.prixUnitaire ? parseFloat(ligne.prixUnitaire).toLocaleString('fr-FR', { minimumFractionDigits: 2 }) : '—';
+            const total = ligne.totalLigne ? parseFloat(ligne.totalLigne).toLocaleString('fr-FR', { minimumFractionDigits: 2 }) + ' €' : '—';
+            const unite = ligne.unite || '';
+
+            return `
+                <tr class="${rowClass}">
+                    <td>
+                        ${this.escapeHtml(ligne.designationBl || '—')}
+                        ${alerteHtml}
+                    </td>
+                    <td class="text-right">${qty}${unite ? ' ' + this.escapeHtml(unite) : ''}</td>
+                    <td class="text-right">${prix} €</td>
+                    <td class="text-right">${total}</td>
+                </tr>
+            `;
+        }).join('');
+
+        this.linesTarget.innerHTML = `
+            <div class="bl-detail-table-header">Lignes (${lignes.length})</div>
+            <table class="bl-detail-table">
+                <thead>
+                    <tr>
+                        <th>Désignation</th>
+                        <th class="text-right">Quantité</th>
+                        <th class="text-right">Prix unit.</th>
+                        <th class="text-right">Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${rows}
+                </tbody>
+            </table>
+        `;
+    }
+
+    async loadImage(bl) {
+        if (!bl.hasImage) return;
+
+        const blob = await getBLImage(bl.id);
+        if (blob) {
+            const url = URL.createObjectURL(blob);
+            const img = document.createElement('img');
+            img.src = url;
+            img.alt = `BL ${bl.numeroBl || bl.id}`;
+            img.onload = () => URL.revokeObjectURL(url);
+            this.imageTarget.innerHTML = '';
+            this.imageTarget.appendChild(img);
+        }
+    }
+
+    async updateCacheStatus() {
+        const lastSync = await getLastBLSyncTime();
+        const isOnline = navigator.onLine;
+
+        if (!isOnline && lastSync) {
+            const timeStr = new Date(lastSync).toLocaleString('fr-FR', {
+                day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit'
+            });
+            this.cacheStatusTarget.innerHTML = `
+                <div class="bl-cache-banner bl-cache-banner--offline">
+                    <i class="fas fa-wifi-slash"></i>
+                    <span>Mode hors connexion — Données en cache</span>
+                    <span class="bl-cache-banner__time">— Sync : ${timeStr}</span>
+                </div>
+            `;
+        }
+    }
+
+    escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+}

--- a/assets/controllers/bl_list_controller.js
+++ b/assets/controllers/bl_list_controller.js
@@ -1,0 +1,198 @@
+import { Controller } from '@hotwired/stimulus';
+import { getBLList, refreshBLCache } from '../js/blCacheManager.js';
+import { getCachedReferentiels, getLastBLSyncTime } from '../js/db.js';
+
+export default class extends Controller {
+    static targets = ['list', 'count', 'emptyState', 'loading', 'cacheStatus', 'filter', 'refreshBtn'];
+
+    async connect() {
+        this._selectedEtablissement = null;
+
+        await this.populateFilter();
+        await this.loadBLs();
+
+        this.onlineHandler = () => this.onOnline();
+        this.offlineHandler = () => this.updateCacheStatus();
+        this.cacheUpdatedHandler = () => this.loadBLsFromCache();
+        window.addEventListener('online', this.onlineHandler);
+        window.addEventListener('offline', this.offlineHandler);
+        window.addEventListener('bl-cache-updated', this.cacheUpdatedHandler);
+
+        // Auto-refresh every 5 minutes when visible
+        this.autoRefreshInterval = setInterval(() => {
+            if (!document.hidden && navigator.onLine) {
+                this.loadBLs();
+            }
+        }, 5 * 60 * 1000);
+    }
+
+    disconnect() {
+        window.removeEventListener('online', this.onlineHandler);
+        window.removeEventListener('offline', this.offlineHandler);
+        window.removeEventListener('bl-cache-updated', this.cacheUpdatedHandler);
+        clearInterval(this.autoRefreshInterval);
+    }
+
+    async onOnline() {
+        await this.loadBLs();
+        this.updateCacheStatus();
+    }
+
+    async populateFilter() {
+        const etablissements = await getCachedReferentiels('etablissements');
+        if (!etablissements || !Array.isArray(etablissements)) return;
+
+        const select = this.filterTarget;
+        etablissements.forEach(etab => {
+            const option = document.createElement('option');
+            option.value = etab.id;
+            option.textContent = etab.nom;
+            select.appendChild(option);
+        });
+    }
+
+    async filterChanged() {
+        const value = this.filterTarget.value;
+        this._selectedEtablissement = value ? parseInt(value) : null;
+        await this.loadBLs();
+    }
+
+    async refresh() {
+        this.refreshBtnTarget.disabled = true;
+        const icon = this.refreshBtnTarget.querySelector('i');
+        icon.classList.add('fa-spin');
+
+        try {
+            await refreshBLCache({ force: true, etablissementId: this._selectedEtablissement });
+            await this.loadBLsFromCache();
+        } finally {
+            this.refreshBtnTarget.disabled = false;
+            icon.classList.remove('fa-spin');
+        }
+    }
+
+    async loadBLs() {
+        this.loadingTarget.classList.remove('hidden');
+        this.listTarget.classList.add('hidden');
+        this.emptyStateTarget.classList.add('hidden');
+
+        try {
+            const bls = await getBLList(this._selectedEtablissement);
+            this.renderList(bls);
+        } catch (error) {
+            console.error('[BLList] Erreur chargement:', error);
+            // Try from cache only
+            await this.loadBLsFromCache();
+        }
+    }
+
+    async loadBLsFromCache() {
+        try {
+            const { getCachedBLs } = await import('../js/db.js');
+            const bls = await getCachedBLs(this._selectedEtablissement);
+            this.renderList(bls);
+        } catch (error) {
+            console.error('[BLList] Erreur cache:', error);
+        }
+    }
+
+    renderList(bls) {
+        this.loadingTarget.classList.add('hidden');
+        this.countTarget.textContent = bls.length;
+
+        if (bls.length === 0) {
+            this.emptyStateTarget.classList.remove('hidden');
+            this.listTarget.classList.add('hidden');
+        } else {
+            this.emptyStateTarget.classList.add('hidden');
+            this.listTarget.classList.remove('hidden');
+            this.listTarget.innerHTML = bls.map(bl => this.renderCard(bl)).join('');
+        }
+
+        this.updateCacheStatus();
+    }
+
+    renderCard(bl) {
+        const statut = bl.statut;
+        const isAnomalie = statut === 'ANOMALIE';
+        const badgeClass = isAnomalie ? 'bl-status-badge--anomalie' : 'bl-status-badge--valide';
+        const badgeIcon = isAnomalie ? 'exclamation-triangle' : 'check-circle';
+        const badgeLabel = isAnomalie ? 'Anomalie' : 'Validé';
+
+        const date = bl.dateLivraison
+            ? new Date(bl.dateLivraison).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+            : '';
+
+        const fournisseur = bl.fournisseur?.nom || 'Fournisseur inconnu';
+        const etablissement = bl.etablissement?.nom || '';
+        const numeroBl = bl.numeroBl || '';
+        const totalHt = bl.totalHt ? parseFloat(bl.totalHt).toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' }) : '';
+
+        return `
+            <a href="/app/bons-livraison/${bl.id}" class="bl-card">
+                <div class="bl-card__inner">
+                    <div class="bl-card__body">
+                        <div class="bl-card__fournisseur">${this.escapeHtml(fournisseur)}</div>
+                        <div class="bl-card__meta">
+                            ${this.escapeHtml(etablissement)}${numeroBl ? ' — N° ' + this.escapeHtml(numeroBl) : ''}${date ? ' — ' + date : ''}
+                        </div>
+                        ${totalHt ? `<div class="bl-card__total">${totalHt}</div>` : ''}
+                    </div>
+                    <div class="bl-card__right">
+                        <span class="bl-status-badge ${badgeClass}">
+                            <i class="fas fa-${badgeIcon}"></i>
+                            ${badgeLabel}
+                        </span>
+                        <span class="bl-card__chevron"><i class="fas fa-chevron-right"></i></span>
+                    </div>
+                </div>
+            </a>
+        `;
+    }
+
+    async updateCacheStatus() {
+        const lastSync = await getLastBLSyncTime();
+        const isOnline = navigator.onLine;
+
+        if (!lastSync) {
+            this.cacheStatusTarget.innerHTML = '';
+            return;
+        }
+
+        const syncDate = new Date(lastSync);
+        const age = Date.now() - syncDate.getTime();
+        const timeStr = syncDate.toLocaleString('fr-FR', {
+            day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit'
+        });
+
+        let bannerClass, icon, text;
+
+        if (!isOnline) {
+            bannerClass = 'bl-cache-banner--offline';
+            icon = 'wifi-slash';
+            text = 'Mode hors connexion — Données en cache';
+        } else if (age > 10 * 60 * 1000) {
+            bannerClass = 'bl-cache-banner--stale';
+            icon = 'clock';
+            text = 'Données en cache';
+        } else {
+            bannerClass = 'bl-cache-banner--fresh';
+            icon = 'check-circle';
+            text = 'Données à jour';
+        }
+
+        this.cacheStatusTarget.innerHTML = `
+            <div class="bl-cache-banner ${bannerClass}">
+                <i class="fas fa-${icon}"></i>
+                <span>${text}</span>
+                <span class="bl-cache-banner__time">— Dernière sync : ${timeStr}</span>
+            </div>
+        `;
+    }
+
+    escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+}

--- a/assets/js/blCacheManager.js
+++ b/assets/js/blCacheManager.js
@@ -1,0 +1,150 @@
+import { getJwtToken } from './syncManager.js';
+import {
+    cacheBLs, getCachedBLs, getCachedBL, cacheBLImage,
+    getCachedBLImage, getLastBLSyncTime, setLastBLSyncTime, evictOldBLImages
+} from './db.js';
+
+const MIN_REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const IMAGE_PREFETCH_COUNT = 10;
+
+let _refreshing = false;
+
+function notifyUI() {
+    window.dispatchEvent(new CustomEvent('bl-cache-updated'));
+}
+
+/**
+ * Refresh the BL cache from the API (incremental sync).
+ * @param {Object} options
+ * @param {boolean} options.force - Skip cooldown check
+ * @param {number|null} options.etablissementId - Filter by etablissement
+ */
+export async function refreshBLCache({ force = false, etablissementId = null } = {}) {
+    if (_refreshing) return;
+    if (!navigator.onLine) return;
+
+    // Skip if synced recently (unless force)
+    if (!force) {
+        const lastSync = await getLastBLSyncTime();
+        if (lastSync && (Date.now() - new Date(lastSync).getTime()) < MIN_REFRESH_INTERVAL) {
+            return;
+        }
+    }
+
+    _refreshing = true;
+
+    try {
+        const token = await getJwtToken();
+        const lastSync = await getLastBLSyncTime();
+
+        const params = new URLSearchParams();
+        if (etablissementId) params.set('etablissementId', String(etablissementId));
+        if (lastSync && !force) params.set('since', lastSync);
+        params.set('limit', '200');
+
+        const url = '/api/bons-livraison' + (params.toString() ? '?' + params.toString() : '');
+
+        const response = await fetch(url, {
+            credentials: 'same-origin',
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+
+        if (!response.ok) {
+            throw new Error(`API error: ${response.status}`);
+        }
+
+        const result = await response.json();
+
+        if (result.success && result.data.length > 0) {
+            await cacheBLs(result.data);
+
+            // Prefetch images for most recent BLs in background
+            prefetchImages(result.data.slice(0, IMAGE_PREFETCH_COUNT), token);
+        }
+
+        await setLastBLSyncTime(new Date().toISOString());
+        notifyUI();
+
+    } catch (error) {
+        console.error('[BLCacheManager] Erreur refresh:', error.message);
+    } finally {
+        _refreshing = false;
+    }
+}
+
+/**
+ * Prefetch images for a list of BLs (non-blocking).
+ */
+async function prefetchImages(bls, token) {
+    for (const bl of bls) {
+        if (!bl.hasImage) continue;
+
+        try {
+            // Skip if already cached
+            const existing = await getCachedBLImage(bl.id);
+            if (existing) continue;
+
+            const response = await fetch(`/api/bons-livraison/${bl.id}/image`, {
+                credentials: 'same-origin',
+                headers: { 'Authorization': `Bearer ${token}` },
+            });
+
+            if (response.ok) {
+                const blob = await response.blob();
+                await cacheBLImage(bl.id, blob);
+            }
+        } catch (error) {
+            // Non-critical: image prefetch failure is not a problem
+            console.warn('[BLCacheManager] Prefetch image échoué pour BL', bl.id);
+        }
+    }
+
+    // Evict old images to stay under limit
+    await evictOldBLImages(50);
+}
+
+/**
+ * Get the list of cached BLs, refreshing first if online.
+ */
+export async function getBLList(etablissementId = null) {
+    await refreshBLCache({ etablissementId });
+    return getCachedBLs(etablissementId);
+}
+
+/**
+ * Get a single cached BL by id.
+ */
+export async function getBLDetail(blId) {
+    return getCachedBL(blId);
+}
+
+/**
+ * Get BL image blob (cache-first: IndexedDB → API fetch → store).
+ */
+export async function getBLImage(blId) {
+    // Try cache first
+    const cached = await getCachedBLImage(blId);
+    if (cached) return cached;
+
+    // Try API if online
+    if (!navigator.onLine) return null;
+
+    try {
+        const token = await getJwtToken();
+        const response = await fetch(`/api/bons-livraison/${blId}/image`, {
+            credentials: 'same-origin',
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+
+        if (!response.ok) return null;
+
+        const blob = await response.blob();
+        await cacheBLImage(blId, blob);
+        await evictOldBLImages(50);
+
+        return blob;
+    } catch (error) {
+        console.warn('[BLCacheManager] Erreur chargement image BL', blId);
+        return null;
+    }
+}

--- a/assets/js/syncManager.js
+++ b/assets/js/syncManager.js
@@ -15,7 +15,7 @@ const MAX_RETRIES = 3;
  * Get a JWT access token, refreshing if needed.
  * Uses the HttpOnly refresh_token cookie (sent automatically for same-origin).
  */
-async function getJwtToken() {
+export async function getJwtToken() {
     // Return cached token if still valid (with 60s safety margin)
     if (_cachedToken && Date.now() < _tokenExpiresAt - 60000) {
         return _cachedToken;

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -18,6 +18,12 @@ framework:
             limit: 10
             interval: '1 minute'
 
+        # Rate limiter for BL read/consultation (60 per minute per user)
+        bl_read:
+            policy: sliding_window
+            limit: 60
+            interval: '1 minute'
+
         # Rate limiter for mercuriale imports (5 per hour per user)
         mercuriale_import:
             policy: sliding_window

--- a/public/css/bl-consultation.css
+++ b/public/css/bl-consultation.css
@@ -1,0 +1,408 @@
+/* ── BL Consultation — Cache Banner ── */
+
+.bl-cache-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    margin-bottom: 1.5rem;
+}
+
+.bl-cache-banner--fresh {
+    background-color: #f0fdf4;
+    color: #166534;
+    border: 1px solid #bbf7d0;
+}
+
+.bl-cache-banner--stale {
+    background-color: #fffbeb;
+    color: #92400e;
+    border: 1px solid #fde68a;
+}
+
+.bl-cache-banner--offline {
+    background-color: #fef3c7;
+    color: #92400e;
+    border: 1px solid #fde68a;
+}
+
+.bl-cache-banner__time {
+    font-weight: 400;
+    opacity: 0.8;
+}
+
+/* ── BL List Cards ── */
+
+.bl-card {
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}
+
+.bl-card:hover {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+    transform: translateY(-1px);
+}
+
+.bl-card__inner {
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.bl-card__fournisseur {
+    font-weight: 600;
+    color: #1e3a5f;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bl-card__meta {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-top: 0.125rem;
+}
+
+.bl-card__total {
+    font-weight: 600;
+    color: #1e3a5f;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+}
+
+.bl-card__body {
+    flex: 1;
+    min-width: 0;
+}
+
+.bl-card__right {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+    flex-shrink: 0;
+}
+
+.bl-card__chevron {
+    color: #9ca3af;
+    font-size: 0.875rem;
+}
+
+/* ── Status Badges ── */
+
+.bl-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.bl-status-badge--valide {
+    background-color: #dcfce7;
+    color: #166534;
+}
+
+.bl-status-badge--anomalie {
+    background-color: #fee2e2;
+    color: #991b1b;
+}
+
+/* ── BL Detail Page ── */
+
+.bl-detail-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+    .bl-detail-layout {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.bl-detail-header {
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 1.5rem;
+}
+
+.bl-detail-header__title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #1e3a5f;
+    margin-bottom: 1rem;
+}
+
+.bl-detail-header__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.bl-detail-header__label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.bl-detail-header__value {
+    font-size: 0.9375rem;
+    color: #1f2937;
+    font-weight: 500;
+}
+
+/* ── BL Detail Table (Lines) ── */
+
+.bl-detail-table-wrapper {
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+.bl-detail-table-header {
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    font-weight: 700;
+    color: #1e3a5f;
+    font-size: 1rem;
+}
+
+.bl-detail-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.bl-detail-table th {
+    text-align: left;
+    padding: 0.625rem 1rem;
+    background: #f9fafb;
+    color: #6b7280;
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.bl-detail-table td {
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid #f3f4f6;
+    color: #374151;
+}
+
+.bl-detail-table tr:last-child td {
+    border-bottom: none;
+}
+
+.bl-detail-table .text-right {
+    text-align: right;
+}
+
+/* ── Alert Rows ── */
+
+.bl-alert-row {
+    background-color: #fef2f2;
+}
+
+.bl-alert-row td {
+    border-bottom-color: #fecaca;
+}
+
+.bl-alert-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: #dc2626;
+    font-size: 0.75rem;
+    font-weight: 500;
+    margin-top: 0.25rem;
+}
+
+/* ── BL Image ── */
+
+.bl-image-container {
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+.bl-image-container img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.bl-image-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    color: #9ca3af;
+    background: #f9fafb;
+    min-height: 200px;
+}
+
+.bl-image-placeholder i {
+    font-size: 3rem;
+    margin-bottom: 0.75rem;
+}
+
+.bl-image-placeholder span {
+    font-size: 0.875rem;
+}
+
+/* ── Loading State ── */
+
+.bl-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 4rem 2rem;
+    color: #6b7280;
+}
+
+.bl-loading i {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+    color: #1e3a5f;
+}
+
+/* ── Empty State ── */
+
+.bl-empty-state {
+    background: #fff;
+    border-radius: 1rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 3rem;
+    text-align: center;
+}
+
+.bl-empty-state__icon {
+    width: 5rem;
+    height: 5rem;
+    margin: 0 auto 1.5rem;
+    background: #f3f4f6;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.bl-empty-state__icon i {
+    font-size: 2rem;
+    color: #9ca3af;
+}
+
+.bl-empty-state__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1e3a5f;
+    margin-bottom: 0.5rem;
+}
+
+.bl-empty-state__text {
+    color: #6b7280;
+}
+
+/* ── Filter Bar ── */
+
+.bl-filter-bar {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.bl-filter-bar select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    background: #fff;
+    color: #374151;
+    flex: 1;
+    min-width: 0;
+}
+
+.bl-filter-bar select:focus {
+    outline: none;
+    border-color: #1e3a5f;
+    box-shadow: 0 0 0 2px rgba(30, 58, 95, 0.15);
+}
+
+/* ── Refresh Button ── */
+
+.bl-refresh-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: #1e3a5f;
+    color: #fff;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s ease;
+    white-space: nowrap;
+}
+
+.bl-refresh-btn:hover {
+    background: #152c4a;
+}
+
+.bl-refresh-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.bl-refresh-btn .fa-spin {
+    animation: fa-spin 1s linear infinite;
+}
+
+/* ── Responsive Adjustments ── */
+
+@media (max-width: 640px) {
+    .bl-detail-header__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .bl-detail-table {
+        font-size: 0.8125rem;
+    }
+
+    .bl-detail-table th,
+    .bl-detail-table td {
+        padding: 0.5rem 0.625rem;
+    }
+
+    .bl-card__inner {
+        padding: 0.75rem;
+        gap: 0.75rem;
+    }
+}

--- a/src/Controller/Api/BonLivraisonReadController.php
+++ b/src/Controller/Api/BonLivraisonReadController.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Entity\BonLivraison;
+use App\Entity\Utilisateur;
+use App\Repository\BonLivraisonRepository;
+use App\Service\Upload\BonLivraisonUploadService;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api')]
+#[IsGranted('ROLE_USER')]
+class BonLivraisonReadController extends AbstractController
+{
+    public function __construct(
+        private readonly BonLivraisonRepository $bonLivraisonRepository,
+        private readonly BonLivraisonUploadService $uploadService,
+        private readonly RateLimiterFactory $blReadLimiter,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/bons-livraison', name: 'api_bons_livraison_list', methods: ['GET'])]
+    public function list(Request $request): JsonResponse
+    {
+        /** @var Utilisateur $user */
+        $user = $this->getUser();
+
+        $limiter = $this->blReadLimiter->create('bl_read_' . $user->getId());
+        if (!$limiter->consume()->isAccepted()) {
+            return $this->json(
+                ['success' => false, 'error' => 'Trop de requêtes. Réessayez dans quelques instants.'],
+                Response::HTTP_TOO_MANY_REQUESTS,
+            );
+        }
+
+        $etablissementId = $request->query->getInt('etablissementId') ?: null;
+        $sinceParam = $request->query->get('since');
+        $limit = min($request->query->getInt('limit', 50), 200);
+
+        $since = null;
+        if ($sinceParam !== null && $sinceParam !== '') {
+            try {
+                $since = new \DateTimeImmutable($sinceParam);
+            } catch (\Exception) {
+                return $this->json(
+                    ['success' => false, 'error' => 'Format de date invalide pour le paramètre since.'],
+                    Response::HTTP_BAD_REQUEST,
+                );
+            }
+        }
+
+        try {
+            $bls = $this->bonLivraisonRepository->findValidatedForUser($user, $etablissementId, $since, $limit);
+
+            $data = array_map(fn (BonLivraison $bl) => $this->serializeBL($bl), $bls);
+
+            return $this->json([
+                'success' => true,
+                'count' => count($data),
+                'data' => $data,
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('Erreur liste BL API', [
+                'user_id' => $user->getId(),
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json(
+                ['success' => false, 'error' => 'Erreur serveur.'],
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }
+
+    #[Route('/bons-livraison/{id}/image', name: 'api_bons_livraison_image', methods: ['GET'])]
+    public function image(BonLivraison $bonLivraison): Response
+    {
+        if (!$this->isGranted('VIEW', $bonLivraison->getEtablissement())) {
+            return $this->json(
+                ['success' => false, 'error' => 'Accès non autorisé.'],
+                Response::HTTP_FORBIDDEN,
+            );
+        }
+
+        $imagePath = $bonLivraison->getImagePath();
+        if (!$imagePath) {
+            throw $this->createNotFoundException('Image non trouvée.');
+        }
+
+        $fullPath = $this->uploadService->getUploadDirectory() . '/' . $imagePath;
+
+        if (!file_exists($fullPath)) {
+            throw $this->createNotFoundException('Image non trouvée.');
+        }
+
+        $response = new BinaryFileResponse($fullPath);
+
+        // Security headers
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Content-Security-Policy', "default-src 'none'");
+        $response->headers->set('X-Frame-Options', 'DENY');
+        // Images are immutable after validation
+        $response->headers->set('Cache-Control', 'private, max-age=86400');
+
+        $response->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_INLINE,
+            'bon-livraison-' . $bonLivraison->getId() . '.jpg'
+        );
+
+        return $response;
+    }
+
+    private function serializeBL(BonLivraison $bl): array
+    {
+        $lignes = [];
+        foreach ($bl->getLignes() as $ligne) {
+            $alertes = [];
+            foreach ($ligne->getAlertes() as $alerte) {
+                $alertes[] = [
+                    'id' => $alerte->getId(),
+                    'typeAlerte' => $alerte->getTypeAlerte()->value,
+                    'message' => $alerte->getMessage(),
+                    'valeurAttendue' => $alerte->getValeurAttendue(),
+                    'valeurRecue' => $alerte->getValeurRecue(),
+                    'ecartPct' => $alerte->getEcartPct(),
+                    'statut' => $alerte->getStatut()->value,
+                ];
+            }
+
+            $lignes[] = [
+                'id' => $ligne->getId(),
+                'designationBl' => $ligne->getDesignationBl(),
+                'codeProduitBl' => $ligne->getCodeProduitBl(),
+                'quantiteLivree' => $ligne->getQuantiteLivree(),
+                'prixUnitaire' => $ligne->getPrixUnitaire(),
+                'totalLigne' => $ligne->getTotalLigne(),
+                'unite' => $ligne->getUnite()?->getNom(),
+                'statutControle' => $ligne->getStatutControle()->value,
+                'ordre' => $ligne->getOrdre(),
+                'alertes' => $alertes,
+            ];
+        }
+
+        return [
+            'id' => $bl->getId(),
+            'numeroBl' => $bl->getNumeroBl(),
+            'dateLivraison' => $bl->getDateLivraison()->format('c'),
+            'statut' => $bl->getStatut()->value,
+            'totalHt' => $bl->getTotalHt(),
+            'hasImage' => $bl->getImagePath() !== null,
+            'validatedAt' => $bl->getValidatedAt()?->format('c'),
+            'fournisseur' => $bl->getFournisseur() ? [
+                'id' => $bl->getFournisseur()->getId(),
+                'nom' => $bl->getFournisseur()->getNom(),
+            ] : null,
+            'etablissement' => [
+                'id' => $bl->getEtablissement()->getId(),
+                'nom' => $bl->getEtablissement()->getNom(),
+            ],
+            'lignes' => $lignes,
+        ];
+    }
+}

--- a/src/Controller/App/BonLivraisonConsultationController.php
+++ b/src/Controller/App/BonLivraisonConsultationController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\App;
+
+use App\Entity\BonLivraison;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/app/bons-livraison')]
+#[IsGranted('ROLE_USER')]
+class BonLivraisonConsultationController extends AbstractController
+{
+    #[Route('', name: 'app_bl_list', methods: ['GET'])]
+    public function list(): Response
+    {
+        return $this->render('app/bon_livraison/list.html.twig');
+    }
+
+    #[Route('/{id}', name: 'app_bl_detail', methods: ['GET'])]
+    public function detail(BonLivraison $bonLivraison): Response
+    {
+        if (!$this->isGranted('VIEW', $bonLivraison->getEtablissement())) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $this->render('app/bon_livraison/detail.html.twig', [
+            'blId' => $bonLivraison->getId(),
+        ]);
+    }
+}

--- a/templates/app/bon_livraison/detail.html.twig
+++ b/templates/app/bon_livraison/detail.html.twig
@@ -1,0 +1,64 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}BL #{{ blId }} - Mercuriale.io{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('css/admin.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/bl-consultation.css') }}">
+{% endblock %}
+
+{% block body %}
+<div class="min-h-screen bg-gradient-to-br from-cream to-cream-dark py-6 px-4"
+     data-controller="bl-detail"
+     data-bl-detail-bl-id-value="{{ blId }}">
+    <div class="max-w-5xl mx-auto">
+        {# Header #}
+        <div class="flex items-center justify-between mb-6">
+            <div>
+                <h1 class="text-2xl font-bold text-navy" data-bl-detail-target="header">
+                    <i class="fas fa-file-invoice mr-2"></i>
+                    Bon de livraison
+                </h1>
+            </div>
+            <a href="{{ path('app_bl_list') }}" class="text-gray-500 hover:text-navy">
+                <i class="fas fa-arrow-left mr-1"></i> Retour à la liste
+            </a>
+        </div>
+
+        {# Cache status #}
+        <div data-bl-detail-target="cacheStatus"></div>
+
+        {# Loading state #}
+        <div data-bl-detail-target="loading" class="bl-loading">
+            <i class="fas fa-spinner fa-spin"></i>
+            <span>Chargement du bon de livraison...</span>
+        </div>
+
+        {# Content (filled by Stimulus controller) #}
+        <div data-bl-detail-target="data" class="hidden">
+            {# Two-column layout: image left, data right #}
+            <div class="bl-detail-layout">
+                {# Image column #}
+                <div data-bl-detail-target="image" class="bl-image-container">
+                    <div class="bl-image-placeholder">
+                        <i class="fas fa-image"></i>
+                        <span>Image non disponible</span>
+                    </div>
+                </div>
+
+                {# Data column #}
+                <div>
+                    {# BL Header info #}
+                    <div data-bl-detail-target="info" class="bl-detail-header">
+                    </div>
+
+                    {# Lines table #}
+                    <div data-bl-detail-target="lines" class="bl-detail-table-wrapper mt-6">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/app/bon_livraison/list.html.twig
+++ b/templates/app/bon_livraison/list.html.twig
@@ -1,0 +1,67 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Bons de livraison - Mercuriale.io{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('css/admin.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/bl-consultation.css') }}">
+{% endblock %}
+
+{% block body %}
+<div class="min-h-screen bg-gradient-to-br from-cream to-cream-dark py-6 px-4"
+     data-controller="bl-list">
+    <div class="max-w-3xl mx-auto">
+        {# Header #}
+        <div class="flex items-center justify-between mb-6">
+            <div>
+                <h1 class="text-2xl font-bold text-navy">
+                    <i class="fas fa-file-invoice mr-2"></i>
+                    Bons de livraison
+                </h1>
+                <p class="text-gray-500 mt-1">
+                    <span data-bl-list-target="count">0</span> bon(s) de livraison
+                </p>
+            </div>
+            <a href="{{ path('admin') }}" class="text-gray-500 hover:text-navy">
+                <i class="fas fa-arrow-left mr-1"></i> Retour
+            </a>
+        </div>
+
+        {# Cache status banner #}
+        <div data-bl-list-target="cacheStatus"></div>
+
+        {# Filter bar #}
+        <div class="bl-filter-bar">
+            <select data-bl-list-target="filter" data-action="bl-list#filterChanged">
+                <option value="">Tous les établissements</option>
+            </select>
+            <button type="button"
+                    data-bl-list-target="refreshBtn"
+                    data-action="bl-list#refresh"
+                    class="bl-refresh-btn">
+                <i class="fas fa-sync-alt"></i>
+                Actualiser
+            </button>
+        </div>
+
+        {# Loading state #}
+        <div data-bl-list-target="loading" class="bl-loading">
+            <i class="fas fa-spinner fa-spin"></i>
+            <span>Chargement des bons de livraison...</span>
+        </div>
+
+        {# Empty state #}
+        <div data-bl-list-target="emptyState" class="bl-empty-state hidden">
+            <div class="bl-empty-state__icon">
+                <i class="fas fa-file-invoice"></i>
+            </div>
+            <h3 class="bl-empty-state__title">Aucun bon de livraison</h3>
+            <p class="bl-empty-state__text">Aucun BL validé trouvé pour cet établissement.</p>
+        </div>
+
+        {# List container #}
+        <div data-bl-list-target="list" class="space-y-3 hidden"></div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Offline BL consultation**: validated BLs (VALIDE + ANOMALIE) cached in IndexedDB for offline browsing
- **API endpoints**: `GET /api/bons-livraison` (list with incremental sync via `?since=`) and `GET /api/bons-livraison/{id}/image` (binary, cached 24h)
- **Client-side rendering**: Stimulus controllers render BL list (cards, filter, auto-refresh) and detail (info grid, lines table, alerts, image from blob)
- **Service Worker v1.4.0**: Cache First for BL images, Network First for BL list API, `bl-consultation.css` pre-cached

## Changes

### Backend
- `BonLivraisonReadController` — JWT-protected read API with rate limiting (`bl_read`: 60/min)
- `BonLivraisonRepository::findValidatedForUser()` — user-scoped query with eager fetching (lignes, alertes, unite, fournisseur)
- `BonLivraisonConsultationController` — Twig shell routes at `/app/bons-livraison`

### Frontend
- **Dexie v2**: `cachedBLs` + `cachedBLImages` tables with LRU eviction (max 50 images)
- **blCacheManager.js**: incremental refresh (5min cooldown), image prefetch (10 most recent), cache-first reads
- **bl_list_controller.js**: card list, etablissement filter, cache status banner, auto-refresh 5min
- **bl_detail_controller.js**: header info, lines table with alert rows, image from IndexedDB blob
- **bl-consultation.css**: cards, badges, detail layout, table, cache banners, responsive
- **syncManager.js**: exported `getJwtToken()` for reuse

## Test plan

- [ ] `GET /api/bons-livraison` returns validated BLs with nested lignes/alertes (curl + JWT)
- [ ] Visit `/app/bons-livraison` → BL list loads with cards showing fournisseur, date, totalHt, status badge
- [ ] Click a BL card → detail page with image, header, lines table, alerts
- [ ] Go offline → refresh list → "Données en cache" banner, data still visible
- [ ] Go offline → view BL detail → image loads from IndexedDB blob
- [ ] Go back online → cache auto-refreshes, new BLs appear
- [ ] Manual refresh button works
- [ ] Etablissement filter filters the list correctly
- [ ] Image eviction: verify max 50 images cached

Closes MERC-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)