### PR TITLE
fix(a11y): add lang attribute and fix login button contrast

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -51,7 +51,7 @@
 .login-container .btn-login {
     width: 100%;
     padding: 12px;
-    background: #007bff;
+    background: #0056d2;
     color: white;
     border: none;
     border-radius: 4px;

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>


### PR DESCRIPTION
## Summary
- Add `lang="fr"` to `<html>` element in `base.html.twig` (Lighthouse a11y failure)
- Darken login button from `#007bff` to `#0056d2` (contrast ratio 3.97:1 → 6.5:1, WCAG AA compliant)

## Test plan
- [x] Lighthouse accessibility score: 79 → **100**
- [x] Zero binary audit failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)