### PR TITLE
fix(migration): add missing image_hash column on bon_livraison

### DIFF
--- a/migrations/Version20260603090000.php
+++ b/migrations/Version20260603090000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260603090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add image_hash column on bon_livraison (SHA-256 for duplicate detection)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bon_livraison ADD image_hash VARCHAR(64) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bon_livraison DROP image_hash');
+    }
+}


### PR DESCRIPTION
## Problème

Sur la base **PostgreSQL** de `develop`, toute requête hydratant un `BonLivraison` (liste des BL, dashboard, upload…) renvoie une **HTTP 500** :

```
SQLSTATE[42703]: Undefined column: 7 ERROR: column b0_.image_hash does not exist
HINT: Perhaps you meant to reference the column "b0_.image_path".
```

## Cause

Le commit `e83c478` (« feat(upload): HEIC support… SHA-256 duplicate detection ») a ajouté le champ `imageHash` à l'entité `BonLivraison` :

```php
#[ORM\Column(length: 64, nullable: true)]
private ?string $imageHash = null;
```

utilisé par `BonLivraisonUploadService` (`findOneBy(['imageHash' => …])`), **mais aucune migration n'a été livrée**. Aucune des migrations de `develop` ne crée la colonne `image_hash` → le mapping et le schéma sont désynchronisés, et Doctrine génère un `SELECT … b0_.image_hash …` sur une colonne inexistante.

## Correctif

Nouvelle migration `Version20260603090000` qui ajoute la colonne, en accord exact avec le mapping :

```sql
ALTER TABLE bon_livraison ADD image_hash VARCHAR(64) DEFAULT NULL
```

## Déploiement

Après merge, appliquer sur develop :

```bash
php bin/console doctrine:migrations:migrate --no-interaction
```

## Vérification

- Syntaxe PHP validée (`php -l`).
- Colonne (`VARCHAR(64)`, nullable) conforme à `#[ORM\Column(length: 64, nullable: true)]`.
- ⚠️ Migration non exécutée dans l'environnement de dev (pas de PostgreSQL disponible) — à confirmer par `doctrine:schema:validate` après `migrate`.

https://claude.ai/code/session_01CD8C71gr2QwfpKa6UTFckV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD8C71gr2QwfpKa6UTFckV)_